### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/enotify.erl
+++ b/src/enotify.erl
@@ -45,6 +45,8 @@ start_link(Path, Events) ->
     case os:type() of
         {unix, darwin} ->
             gen_server:start_link(?MODULE, [enotify_fsevents, Path, Events, self()], []);
+        {unix, freebsd} ->
+            gen_server:start_link(?MODULE, [enotify_inotifywait, Path, Events, self()], []);
         {unix, linux} ->
             gen_server:start_link(?MODULE, [enotify_inotifywait, Path, Events, self()], []);
         {win32, nt} ->


### PR DESCRIPTION
FreeBSD uses inotifywait(1) like Linux.

The only change is the oneliner used to call it: argument parsing is stopped with a `--` just after `-c "<command line>"` on FreeBSD, otherwise sh(1) eats `-m` and `-e`. That change is made specific to FreeBSD. It is possible this would work on Linux too, but I don't have all the Dash/Bash/etc. implementations at hands, so let's not break something which works for years.